### PR TITLE
Upgrade to GA version of Spring Boot 2.0, remove comment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,6 @@ allprojects{
 
     repositories {
         mavenCentral()
-        maven { url "https://repo.spring.io/milestone" }
     }
 
 }

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -7,9 +7,9 @@ com.google.guava:guava=23.0
 org.slf4j:slf4j-api=1.7.21
 org.slf4j:slf4j-simple=1.7.21
 
-org.springframework.boot:spring-boot-starter-actuator=2.0.0.RC1
-org.springframework.boot:spring-boot-starter-web=2.0.0.RC1
-org.springframework.boot:spring-boot-starter-test=2.0.0.RC1
+org.springframework.boot:spring-boot-starter-actuator=2.0.0.RELEASE
+org.springframework.boot:spring-boot-starter-web=2.0.0.RELEASE
+org.springframework.boot:spring-boot-starter-test=2.0.0.RELEASE
 
 org.springframework.restdocs:spring-restdocs-asciidoctor=2.0.0.RELEASE
 org.springframework.restdocs:spring-restdocs-mockmvc=2.0.0.RELEASE

--- a/main.webapp/src/test/java/org/starchartlabs/river/test/util/StarchartLinkExtractor.java
+++ b/main.webapp/src/test/java/org/starchartlabs/river/test/util/StarchartLinkExtractor.java
@@ -18,8 +18,6 @@ public class StarchartLinkExtractor implements LinkExtractor {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     
-    // TODO nickavv pending Spring Restdoc accepting my pull request, 
-    // this class could extend AbstractJsonLinkExtractor and be simplified
     @Override
     public Map<String, List<Link>> extractLinks(OperationResponse response)
             throws IOException {


### PR DESCRIPTION
Upgrading to Spring Boot 2.0 GA, since it is now out.
Also removed comment about wanting to simplify LinkExtractor since Spring Restdoc team rejected my PR.